### PR TITLE
[feat] 프로필 관련 기능 구현

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -81,6 +81,15 @@ jobs:
           echo "${{ secrets.YML_OAUTH }}" > ./application-oauth.yml
         shell: bash
 
+      # 환경별 yml 파일 생성(5) - bucket
+      - name: make application-bucket.yml
+        if: contains(github.ref, 'develop')
+        run: |
+          cd ./src/main/resources
+          touch ./application-bucket.yml
+          echo "${{ secrets.YML_BUCKET }}" > ./application-bucket.yml
+        shell: bash
+
       # gradle build
       - name: Build with Gradle
         run: ./gradlew build -x test

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // S3 Bucket
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0'
 
 }

--- a/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
 			.body(GlobalResponseDto.success(userService.getProfile(request)));
 	}
 
-	@PutMapping("/info")
+	@PatchMapping("/info")
 	@Operation(summary = "프로필 수정", description = "사용자의 프로필을 수정합니다.")
 	public ResponseEntity<GlobalResponseDto<String>> updateProfile(@RequestBody UserProfileRequestDto userProfileRequestDto, HttpServletRequest request) {
 		userService.updateProfile(request,userProfileRequestDto);

--- a/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
@@ -6,14 +6,18 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.leets.xcellentbe.domain.user.domain.User;
 import com.leets.xcellentbe.domain.user.dto.UserLoginRequestDto;
+import com.leets.xcellentbe.domain.user.dto.UserProfileRequestDto;
 import com.leets.xcellentbe.domain.user.dto.UserProfileResponseDto;
 import com.leets.xcellentbe.domain.user.dto.UserSignUpRequestDto;
 import com.leets.xcellentbe.domain.user.service.UserService;
+import com.leets.xcellentbe.global.auth.email.EmailRequestDto;
 import com.leets.xcellentbe.global.response.GlobalResponseDto;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,9 +37,10 @@ public class UserController {
 			.body(GlobalResponseDto.success(userService.getProfile(request)));
 	}
 
-	@PatchMapping("/{userId}")
+	@PutMapping("/info")
 	@Operation(summary = "프로필 수정", description = "사용자의 프로필을 수정합니다.")
-	public String updateProfile(@RequestBody UserLoginRequestDto userLoginRequestDto) {
-		return "로그인 성공";
+	public ResponseEntity<GlobalResponseDto<String>> updateProfile(@RequestBody UserProfileRequestDto userProfileRequestDto, HttpServletRequest request) {
+		userService.updateProfile(request,userProfileRequestDto);
+		return ResponseEntity.status(HttpStatus.OK).body(GlobalResponseDto.success());
 	}
 }

--- a/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.leets.xcellentbe.domain.user.controller;
 
+import java.io.IOException;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,13 +11,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.leets.xcellentbe.domain.user.domain.User;
 import com.leets.xcellentbe.domain.user.dto.UserLoginRequestDto;
 import com.leets.xcellentbe.domain.user.dto.UserProfileRequestDto;
 import com.leets.xcellentbe.domain.user.dto.UserProfileResponseDto;
 import com.leets.xcellentbe.domain.user.dto.UserSignUpRequestDto;
+import com.leets.xcellentbe.domain.user.service.S3UploadService;
 import com.leets.xcellentbe.domain.user.service.UserService;
 import com.leets.xcellentbe.global.auth.email.EmailRequestDto;
 import com.leets.xcellentbe.global.response.GlobalResponseDto;
@@ -29,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserController {
 	private final UserService userService;
+	private final S3UploadService s3UploadService;
 
 	@GetMapping("/info")
 	@Operation(summary = "프로필 조회", description = "사용자의 프로필 내용을 조회합니다.")
@@ -43,4 +49,19 @@ public class UserController {
 		userService.updateProfile(request,userProfileRequestDto);
 		return ResponseEntity.status(HttpStatus.OK).body(GlobalResponseDto.success());
 	}
-}
+
+	@PostMapping("/profile-image")
+	@Operation(summary = "프로필 이미지 수정", description = "사용자의 프로필 이미지를 수정합니다.")
+	public ResponseEntity<GlobalResponseDto<String>> updateProfileImage(@RequestParam("file") MultipartFile file, HttpServletRequest request) {
+			return ResponseEntity.status(HttpStatus.OK)
+				.body(GlobalResponseDto.success(userService.updateProfileImage(file, request)));
+
+	}
+
+	@PostMapping("/background-image")
+	@Operation(summary = "배경 이미지 수정", description = "사용자의 배경 이미지를 수정합니다.")
+	public ResponseEntity<GlobalResponseDto<String>> updateBackgroundImage (@RequestParam("file") MultipartFile file, HttpServletRequest request){
+			return ResponseEntity.status(HttpStatus.OK)
+				.body(GlobalResponseDto.success(userService.updateBackgroundProfileImage(file, request)));
+		}
+	}

--- a/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
@@ -34,7 +34,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserController {
 	private final UserService userService;
-	private final S3UploadService s3UploadService;
 
 	@GetMapping("/info")
 	@Operation(summary = "프로필 조회", description = "사용자의 프로필 내용을 조회합니다.")

--- a/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
@@ -2,36 +2,40 @@ package com.leets.xcellentbe.domain.user.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.leets.xcellentbe.domain.user.dto.UserLoginRequestDto;
+import com.leets.xcellentbe.domain.user.dto.UserProfileResponseDto;
 import com.leets.xcellentbe.domain.user.dto.UserSignUpRequestDto;
 import com.leets.xcellentbe.domain.user.service.UserService;
 import com.leets.xcellentbe.global.response.GlobalResponseDto;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/user")
+@RequestMapping("/api/profile")
 @RequiredArgsConstructor
 public class UserController {
-	// private final UserService userService;
-	//
-	// @PostMapping("/auth/register")
-	// @Operation(summary = "회원가입", description = "회원가입을 합니다.")
-	// public ResponseEntity<GlobalResponseDto<String>> register(@RequestBody UserSignUpRequestDto userSignUpRequestDto) {
-	// 	return ResponseEntity.status(HttpStatus.CREATED)
-	// 		.body(GlobalResponseDto.success(userService.register(userSignUpRequestDto), HttpStatus.CREATED.value()));
-	// }
-	//
-	// @Operation(summary = "로그인", description = "사용자의 이메일과 비밀번호로 로그인합니다.")
-	// @PostMapping("/auth/login")
-	// public String login(@RequestBody UserLoginRequestDto userLoginRequestDto) {
-	// 	// 로그인 로직 처리
-	// 	return "로그인 성공";
-	// }
+	private final UserService userService;
+
+	@GetMapping("/info")
+	@Operation(summary = "프로필 조회", description = "사용자의 프로필 내용을 조회합니다.")
+	public ResponseEntity<GlobalResponseDto<UserProfileResponseDto>> getProfile(HttpServletRequest request) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(GlobalResponseDto.success(userService.getProfile(request)));
+	}
+
+	@PatchMapping("/{userId}")
+	@Operation(summary = "프로필 수정", description = "사용자의 프로필을 수정합니다.")
+	public String updateProfile(@RequestBody UserLoginRequestDto userLoginRequestDto) {
+		return "로그인 성공";
+	}
 }

--- a/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/controller/UserController.java
@@ -49,7 +49,7 @@ public class UserController {
 		return ResponseEntity.status(HttpStatus.OK).body(GlobalResponseDto.success());
 	}
 
-	@PostMapping("/profile-image")
+	@PatchMapping("/profile-image")
 	@Operation(summary = "프로필 이미지 수정", description = "사용자의 프로필 이미지를 수정합니다.")
 	public ResponseEntity<GlobalResponseDto<String>> updateProfileImage(@RequestParam("file") MultipartFile file, HttpServletRequest request) {
 			return ResponseEntity.status(HttpStatus.OK)
@@ -57,7 +57,7 @@ public class UserController {
 
 	}
 
-	@PostMapping("/background-image")
+	@PatchMapping("/background-image")
 	@Operation(summary = "배경 이미지 수정", description = "사용자의 배경 이미지를 수정합니다.")
 	public ResponseEntity<GlobalResponseDto<String>> updateBackgroundImage (@RequestParam("file") MultipartFile file, HttpServletRequest request){
 			return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/leets/xcellentbe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/domain/User.java
@@ -126,11 +126,9 @@ public class User extends BaseTimeEntity {
 			.build();
 	}
 
-	public void updateProfile(String userName, String phoneNumber, String customId, int userBirthYear, int userBirthDay, int userBirthMonth, String profileImageUrl, String backgroundProfileImageUrl, String description, String websiteUrl, String location) {
+	public void updateProfile(String userName, String phoneNumber, String customId, int userBirthYear, int userBirthDay, int userBirthMonth, String description, String websiteUrl, String location) {
 		this.userName = userName;
 		this.customId = customId;
-		this.profileImageUrl = profileImageUrl;
-		this.backgroundProfileImageUrl = backgroundProfileImageUrl;
 		this.description = description;
 		this.websiteUrl = websiteUrl;
 		this.location = location;
@@ -138,6 +136,14 @@ public class User extends BaseTimeEntity {
 		this.userBirthYear = userBirthYear;
 		this.userBirthDay = userBirthDay;
 		this.userBirthMonth = userBirthMonth;
+	}
+
+	public void updateProfileImage(String updateProfileImageUrl) {
+		this.profileImageUrl = updateProfileImageUrl;
+	}
+
+	public void updateBackgroundImage(String updateBackgroundImageUrl) {
+		this.backgroundProfileImageUrl = updateBackgroundImageUrl;
 	}
 
 	public void updateRefreshToken(String updateRefreshToken) {

--- a/src/main/java/com/leets/xcellentbe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/domain/User.java
@@ -126,12 +126,18 @@ public class User extends BaseTimeEntity {
 			.build();
 	}
 
-	public static User socialCreate(String email, String socialEmail) {
-		return User.builder()
-			.email(email)
-			.userRole(Role.GUEST)
-			.socialEmail(socialEmail)
-			.build();
+	public void updateProfile(String userName, String phoneNumber, String customId, int userBirthYear, int userBirthDay, int userBirthMonth, String profileImageUrl, String backgroundProfileImageUrl, String description, String websiteUrl, String location) {
+		this.userName = userName;
+		this.customId = customId;
+		this.profileImageUrl = profileImageUrl;
+		this.backgroundProfileImageUrl = backgroundProfileImageUrl;
+		this.description = description;
+		this.websiteUrl = websiteUrl;
+		this.location = location;
+		this.phoneNumber = phoneNumber;
+		this.userBirthYear = userBirthYear;
+		this.userBirthDay = userBirthDay;
+		this.userBirthMonth = userBirthMonth;
 	}
 
 	public void updateRefreshToken(String updateRefreshToken) {

--- a/src/main/java/com/leets/xcellentbe/domain/user/dto/UserProfileRequestDto.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/dto/UserProfileRequestDto.java
@@ -1,0 +1,22 @@
+package com.leets.xcellentbe.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+
+public class UserProfileRequestDto {
+	private String customId;
+	private String userName;
+	private String profileImageUrl;
+	private String backgroundProfileImageUrl;
+	private String phoneNumber;
+	private String description;
+	private String websiteUrl;
+	private String location;
+	private int userBirthYear;
+	private int userBirthMonth;
+	private int userBirthDay;
+}

--- a/src/main/java/com/leets/xcellentbe/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/dto/UserProfileResponseDto.java
@@ -1,5 +1,7 @@
 package com.leets.xcellentbe.domain.user.dto;
 
+import com.leets.xcellentbe.domain.user.domain.User;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,5 +38,22 @@ public class UserProfileResponseDto {
 		this.userBirthYear = userBirthYear;
 		this.userBirthMonth = userBirthMonth;
 		this.userBirthDay = userBirthDay;
+	}
+
+	public static UserProfileResponseDto from(User user) {
+		return UserProfileResponseDto.builder()
+			.email(user.getEmail())
+			.customId(user.getCustomId())
+			.userName(user.getUserName())
+			.profileImageUrl(user.getProfileImageUrl())
+			.backgroundProfileImageUrl(user.getBackgroundProfileImageUrl())
+			.phoneNumber(user.getPhoneNumber())
+			.description(user.getDescription())
+			.websiteUrl(user.getWebsiteUrl())
+			.location(user.getLocation())
+			.userBirthYear(user.getUserBirthYear())
+			.userBirthMonth(user.getUserBirthMonth())
+			.userBirthDay(user.getUserBirthDay())
+			.build();
 	}
 }

--- a/src/main/java/com/leets/xcellentbe/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/dto/UserProfileResponseDto.java
@@ -1,0 +1,40 @@
+package com.leets.xcellentbe.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class UserProfileResponseDto {
+	private String email;
+	private String customId;
+	private String userName;
+	private String profileImageUrl;
+	private String backgroundProfileImageUrl;
+	private String phoneNumber;
+	private String description;
+	private String websiteUrl;
+	private String location;
+	private int userBirthYear;
+	private int userBirthMonth;
+	private int userBirthDay;
+
+	@Builder
+	private UserProfileResponseDto(String email, String customId, String userName, String profileImageUrl,
+		String backgroundProfileImageUrl, String phoneNumber, String description, String websiteUrl, String location,
+		int userBirthYear, int userBirthMonth, int userBirthDay) {
+		this.email = email;
+		this.customId = customId;
+		this.userName = userName;
+		this.profileImageUrl = profileImageUrl;
+		this.backgroundProfileImageUrl = backgroundProfileImageUrl;
+		this.phoneNumber = phoneNumber;
+		this.description = description;
+		this.websiteUrl = websiteUrl;
+		this.location = location;
+		this.userBirthYear = userBirthYear;
+		this.userBirthMonth = userBirthMonth;
+		this.userBirthDay = userBirthDay;
+	}
+}

--- a/src/main/java/com/leets/xcellentbe/domain/user/exception/InvalidFileFormat.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/exception/InvalidFileFormat.java
@@ -1,0 +1,10 @@
+package com.leets.xcellentbe.domain.user.exception;
+
+import com.leets.xcellentbe.global.error.ErrorCode;
+import com.leets.xcellentbe.global.error.exception.CommonException;
+
+public class InvalidFileFormat extends CommonException {
+	public InvalidFileFormat() {
+		super(ErrorCode.INVALID_FILE_FORMAT);
+	}
+}

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/S3UploadService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/S3UploadService.java
@@ -1,0 +1,80 @@
+package com.leets.xcellentbe.domain.user.service;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class S3UploadService {
+	private final AmazonS3Client amazonS3Client;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	// MultipartFile을 전달받아 File로 전환한 후 S3에 업로드
+	public String upload(MultipartFile multipartFile, String dirName) { // dirName의 디렉토리가 S3 Bucket 내부에 생성됨
+		try {
+			File uploadFile = convert(multipartFile).
+				orElseThrow(() -> new RuntimeException());
+			return upload(uploadFile, dirName);
+		} catch(IOException e) {
+			throw new RuntimeException();
+		}
+
+	}
+
+	private String upload(File uploadFile, String dirName) {
+		String fileName = dirName + "/" + uploadFile.getName();
+		String uploadImageUrl = putS3(uploadFile, fileName);
+
+		removeNewFile(uploadFile);  // convert()함수로 인해서 로컬에 생성된 File 삭제 (MultipartFile -> File 전환 하며 로컬에 파일 생성됨)
+
+		return uploadImageUrl;      // 업로드된 파일의 S3 URL 주소 반환
+	}
+
+	private String putS3(File uploadFile, String fileName) {
+		amazonS3Client.putObject(
+			new PutObjectRequest(bucket, fileName, uploadFile)
+				.withCannedAcl(CannedAccessControlList.PublicRead)	// PublicRead 권한으로 업로드 됨
+		);
+		return amazonS3Client.getUrl(bucket, fileName).toString();
+	}
+
+	private void removeNewFile(File targetFile) {
+		if(targetFile.delete()) {
+			log.info("파일이 삭제되었습니다.");
+		}else {
+			log.info("파일이 삭제되지 못했습니다.");
+		}
+	}
+
+	private Optional<File> convert(MultipartFile file) throws  IOException {
+		File convertFile = new File(file.getOriginalFilename()); // 업로드한 파일의 이름
+		if(convertFile.createNewFile()) {
+			try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+				fos.write(file.getBytes());
+			}
+			return Optional.of(convertFile);
+		}
+		return Optional.empty();
+	}
+
+	public void removeFile(String fileUrl) {
+		String fileName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+		amazonS3Client.deleteObject(bucket, fileUrl);
+	}
+}

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/S3UploadService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/S3UploadService.java
@@ -12,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.leets.xcellentbe.domain.user.exception.InvalidFileFormat;
 import com.leets.xcellentbe.global.error.exception.custom.InternalServerErrorException;
 
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,11 @@ public class S3UploadService {
 
 	// MultipartFile을 전달받아 File로 전환한 후 S3에 업로드
 	public String upload(MultipartFile multipartFile, String dirName) { // dirName의 디렉토리가 S3 Bucket 내부에 생성됨
+		String fileName = multipartFile.getOriginalFilename();
+		if ((fileName.endsWith(".png") || fileName.endsWith(".jpg"))) {
+			throw new InvalidFileFormat();
+		}
+
 		try {
 			File uploadFile = convert(multipartFile).
 				orElseThrow(() -> new RuntimeException());

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/S3UploadService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/S3UploadService.java
@@ -62,7 +62,7 @@ public class S3UploadService {
 		}
 	}
 
-	private Optional<File> convert(MultipartFile file) throws  IOException {
+	private Optional<File> convert(MultipartFile file) throws IOException {
 		File convertFile = new File(file.getOriginalFilename()); // 업로드한 파일의 이름
 		if(convertFile.createNewFile()) {
 			try (FileOutputStream fos = new FileOutputStream(convertFile)) {
@@ -73,8 +73,8 @@ public class S3UploadService {
 		return Optional.empty();
 	}
 
-	public void removeFile(String fileUrl) {
+	public void removeFile(String fileUrl, String filePath) {
 		String fileName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
-		amazonS3Client.deleteObject(bucket, fileName);
+		amazonS3Client.deleteObject(bucket, filePath + fileName);
 	}
 }

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/S3UploadService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/S3UploadService.java
@@ -12,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.leets.xcellentbe.global.error.exception.custom.InternalServerErrorException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +33,7 @@ public class S3UploadService {
 				orElseThrow(() -> new RuntimeException());
 			return upload(uploadFile, dirName);
 		} catch(IOException e) {
-			throw new RuntimeException();
+			throw new InternalServerErrorException();
 		}
 
 	}

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/S3UploadService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/S3UploadService.java
@@ -75,6 +75,6 @@ public class S3UploadService {
 
 	public void removeFile(String fileUrl) {
 		String fileName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
-		amazonS3Client.deleteObject(bucket, fileUrl);
+		amazonS3Client.deleteObject(bucket, fileName);
 	}
 }

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
@@ -53,31 +53,31 @@ public class UserService {
 
 	// 사용자 정보 조회 메소드
 	public UserProfileResponseDto getProfile(HttpServletRequest request) {
-		Optional<User> user = getUser(request);
+		User user = getUser(request);
 		return UserProfileResponseDto.builder()
-			.customId(user.get().getCustomId())
-			.email(user.get().getEmail())
-			.userName(user.get().getUserName())
-			.phoneNumber(user.get().getPhoneNumber())
-			.userBirthYear(user.get().getUserBirthYear())
-			.userBirthDay(user.get().getUserBirthDay())
-			.userBirthMonth(user.get().getUserBirthMonth())
+			.customId(user.getCustomId())
+			.email(user.getEmail())
+			.userName(user.getUserName())
+			.phoneNumber(user.getPhoneNumber())
+			.userBirthYear(user.getUserBirthYear())
+			.userBirthDay(user.getUserBirthDay())
+			.userBirthMonth(user.getUserBirthMonth())
 			.build();
 	}
 
 
 	// 사용자 정보 수정 메소드
 	public void updateProfile(HttpServletRequest request, UserProfileRequestDto userProfileRequestDto) {
-		Optional<User> user = getUser(request);
-		user.get().updateProfile(userProfileRequestDto.getUserName(), userProfileRequestDto.getPhoneNumber(), userProfileRequestDto.getCustomId(), userProfileRequestDto.getUserBirthYear(), userProfileRequestDto.getUserBirthDay(), userProfileRequestDto.getUserBirthMonth(), userProfileRequestDto.getDescription(), userProfileRequestDto.getWebsiteUrl(), userProfileRequestDto.getLocation());
+		User user = getUser(request);
+		user.updateProfile(userProfileRequestDto.getUserName(), userProfileRequestDto.getPhoneNumber(), userProfileRequestDto.getCustomId(), userProfileRequestDto.getUserBirthYear(), userProfileRequestDto.getUserBirthDay(), userProfileRequestDto.getUserBirthMonth(), userProfileRequestDto.getDescription(), userProfileRequestDto.getWebsiteUrl(), userProfileRequestDto.getLocation());
 	}
 
 	// 프로필 이미지 변경 메소드
 	public String updateProfileImage(MultipartFile multipartFile, HttpServletRequest request) {
-		Optional<User> user = getUser(request);
-		String priorUrl = user.get().getProfileImageUrl();
+		User user = getUser(request);
+		String priorUrl = user.getProfileImageUrl();
 		String url = s3UploadService.upload(multipartFile, "profile-image");
-		user.get().updateProfileImage(url);
+		user.updateProfileImage(url);
 
 		if (priorUrl != null) {
 			s3UploadService.removeFile(priorUrl);
@@ -88,10 +88,10 @@ public class UserService {
 
 	// 배경 이미지 변경 메소드
 	public String updateBackgroundProfileImage(MultipartFile multipartFile, HttpServletRequest request) {
-		Optional<User> user = getUser(request);
-		String priorUrl = user.get().getBackgroundProfileImageUrl();
+		User user = getUser(request);
+		String priorUrl = user.getBackgroundProfileImageUrl();
 		String url = s3UploadService.upload(multipartFile, "background-image");
-		user.get().updateBackgroundImage(url);
+		user.updateBackgroundImage(url);
 
 		if (priorUrl != null) {
 			s3UploadService.removeFile(priorUrl);
@@ -101,7 +101,7 @@ public class UserService {
 	}
 
 	//JWT 토큰 해독하여 사용자 정보 반환 메소드
-	private Optional<User> getUser(HttpServletRequest request) {
+	private User getUser(HttpServletRequest request) {
 		Optional<User> user = jwtService.extractAccessToken(request)
 			.filter(jwtService::isTokenValid)
 			.flatMap(accessToken -> jwtService.extractEmail(accessToken))
@@ -111,7 +111,7 @@ public class UserService {
 			throw new UserNotFoundException();
 		}
 
-		return user;
+		return user.get();
 	}
 
 }

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
@@ -12,6 +12,7 @@ import com.leets.xcellentbe.domain.user.exception.UserAlreadyExistsException;
 import com.leets.xcellentbe.domain.user.domain.repository.UserRepository;
 import com.leets.xcellentbe.domain.user.dto.UserSignUpRequestDto;
 
+import com.leets.xcellentbe.domain.user.exception.UserNotFoundException;
 import com.leets.xcellentbe.global.auth.jwt.JwtService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -75,6 +76,11 @@ public class UserService {
 			.filter(jwtService::isTokenValid)
 			.flatMap(accessToken -> jwtService.extractEmail(accessToken))
 			.flatMap(email -> userRepository.findByEmail(email));
+
+		if (user.isEmpty()) {
+			throw new UserNotFoundException();
+		}
+
 		return user;
 	}
 

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.leets.xcellentbe.domain.user.service;
 
 import java.util.Optional;
 
+import org.hibernate.engine.transaction.jta.platform.internal.SunOneJtaPlatform;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -78,9 +79,8 @@ public class UserService {
 		String priorUrl = user.getProfileImageUrl();
 		String url = s3UploadService.upload(multipartFile, "profile-image");
 		user.updateProfileImage(url);
-
 		if (priorUrl != null) {
-			s3UploadService.removeFile(priorUrl);
+			s3UploadService.removeFile(priorUrl, "profile-image/");
 		}
 
 		return url;
@@ -94,7 +94,7 @@ public class UserService {
 		user.updateBackgroundImage(url);
 
 		if (priorUrl != null) {
-			s3UploadService.removeFile(priorUrl);
+			s3UploadService.removeFile(priorUrl, "background-image/");
 		}
 
 		return url;

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.leets.xcellentbe.domain.user.service;
 
+import java.util.Optional;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -9,6 +11,11 @@ import com.leets.xcellentbe.domain.user.exception.UserAlreadyExistsException;
 import com.leets.xcellentbe.domain.user.domain.repository.UserRepository;
 import com.leets.xcellentbe.domain.user.dto.UserSignUpRequestDto;
 
+import com.leets.xcellentbe.global.auth.jwt.JwtService;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import com.leets.xcellentbe.domain.user.dto.UserProfileResponseDto;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +26,7 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final JwtService jwtService;
 
 	public String register(UserSignUpRequestDto userSignUpRequestDto) {
 
@@ -36,6 +44,23 @@ public class UserService {
 		userRepository.save(user);
 
 		return "회원가입이 완료되었습니다.";
+	}
+
+	public UserProfileResponseDto getProfile(HttpServletRequest request) {
+		Optional<User> user = jwtService.extractAccessToken(request)
+			.filter(jwtService::isTokenValid)
+			.flatMap(accessToken -> jwtService.extractEmail(accessToken))
+			.flatMap(email -> userRepository.findByEmail(email));
+
+		return UserProfileResponseDto.builder()
+			.customId(user.get().getCustomId())
+			.email(user.get().getEmail())
+			.userName(user.get().getUserName())
+			.phoneNumber(user.get().getPhoneNumber())
+			.userBirthYear(user.get().getUserBirthYear())
+			.userBirthDay(user.get().getUserBirthDay())
+			.userBirthMonth(user.get().getUserBirthMonth())
+			.build();
 	}
 
 }

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.leets.xcellentbe.domain.user.domain.User;
+import com.leets.xcellentbe.domain.user.dto.UserProfileRequestDto;
 import com.leets.xcellentbe.domain.user.exception.UserAlreadyExistsException;
 
 import com.leets.xcellentbe.domain.user.domain.repository.UserRepository;
@@ -28,6 +29,7 @@ public class UserService {
 	private final PasswordEncoder passwordEncoder;
 	private final JwtService jwtService;
 
+	// 회원가입 메소드
 	public String register(UserSignUpRequestDto userSignUpRequestDto) {
 
 		if (userRepository.findByEmail(userSignUpRequestDto.getEmail()).isPresent()) {
@@ -46,12 +48,9 @@ public class UserService {
 		return "회원가입이 완료되었습니다.";
 	}
 
+	// 사용자 정보 조회 메소드
 	public UserProfileResponseDto getProfile(HttpServletRequest request) {
-		Optional<User> user = jwtService.extractAccessToken(request)
-			.filter(jwtService::isTokenValid)
-			.flatMap(accessToken -> jwtService.extractEmail(accessToken))
-			.flatMap(email -> userRepository.findByEmail(email));
-
+		Optional<User> user = getUser(request);
 		return UserProfileResponseDto.builder()
 			.customId(user.get().getCustomId())
 			.email(user.get().getEmail())
@@ -61,6 +60,22 @@ public class UserService {
 			.userBirthDay(user.get().getUserBirthDay())
 			.userBirthMonth(user.get().getUserBirthMonth())
 			.build();
+	}
+
+
+	// 사용자 정보 수정 메소드
+	public void updateProfile(HttpServletRequest request, UserProfileRequestDto userProfileRequestDto) {
+		Optional<User> user = getUser(request);
+		user.get().updateProfile(userProfileRequestDto.getUserName(), userProfileRequestDto.getPhoneNumber(), userProfileRequestDto.getCustomId(), userProfileRequestDto.getUserBirthYear(), userProfileRequestDto.getUserBirthDay(), userProfileRequestDto.getUserBirthMonth(), userProfileRequestDto.getProfileImageUrl(), userProfileRequestDto.getBackgroundProfileImageUrl(), userProfileRequestDto.getDescription(), userProfileRequestDto.getWebsiteUrl(), userProfileRequestDto.getLocation());
+	}
+
+	//JWT 토큰 해독하여 사용자 정보 반환 메소드
+	private Optional<User> getUser(HttpServletRequest request) {
+		Optional<User> user = jwtService.extractAccessToken(request)
+			.filter(jwtService::isTokenValid)
+			.flatMap(accessToken -> jwtService.extractEmail(accessToken))
+			.flatMap(email -> userRepository.findByEmail(email));
+		return user;
 	}
 
 }

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
@@ -55,15 +55,7 @@ public class UserService {
 	// 사용자 정보 조회 메소드
 	public UserProfileResponseDto getProfile(HttpServletRequest request) {
 		User user = getUser(request);
-		return UserProfileResponseDto.builder()
-			.customId(user.getCustomId())
-			.email(user.getEmail())
-			.userName(user.getUserName())
-			.phoneNumber(user.getPhoneNumber())
-			.userBirthYear(user.getUserBirthYear())
-			.userBirthDay(user.getUserBirthDay())
-			.userBirthMonth(user.getUserBirthMonth())
-			.build();
+		return UserProfileResponseDto.from(user);
 	}
 
 

--- a/src/main/java/com/leets/xcellentbe/global/auth/email/EmailService.java
+++ b/src/main/java/com/leets/xcellentbe/global/auth/email/EmailService.java
@@ -29,7 +29,7 @@ public class EmailService {
 
 
 	//mail을 어디서 보내는지, 어디로 보내는지 , 인증 번호를 html 형식으로 어떻게 보내는지 작성합니다.
-	public String joinEmail(String email) throws MessagingException {
+	public String joinEmail(String email)  {
 		makeRandomNumber();
 		String toMail = email;
 		String title = "회원 가입 인증 이메일 입니다."; // 이메일 제목
@@ -42,7 +42,7 @@ public class EmailService {
 	}
 
 	//이메일을 전송합니다.
-	public void mailSend(String toMail, String title, String content) throws MessagingException {
+	public void mailSend(String toMail, String title, String content) {
 
 		if(redisService.getData(toMail)!=null){
 			throw new AuthCodeAlreadySentException();

--- a/src/main/java/com/leets/xcellentbe/global/auth/jwt/JwtService.java
+++ b/src/main/java/com/leets/xcellentbe/global/auth/jwt/JwtService.java
@@ -114,8 +114,8 @@ public class JwtService {
 	 */
 	public Optional<String> extractAccessToken(HttpServletRequest request) {
 		return Optional.ofNullable(request.getHeader(accessHeader))
-			.filter(refreshToken -> refreshToken.startsWith(BEARER))
-			.map(refreshToken -> refreshToken.replace(BEARER, ""));
+			.filter(accessToken -> accessToken.startsWith(BEARER))
+			.map(accessToken -> accessToken.replace(BEARER, ""));
 	}
 
 	/**
@@ -135,6 +135,7 @@ public class JwtService {
 				.asString());
 		} catch (Exception e) {
 			log.error("액세스 토큰이 유효하지 않습니다.");
+			e.printStackTrace();
 			return Optional.empty();
 		}
 	}

--- a/src/main/java/com/leets/xcellentbe/global/auth/login/AuthController.java
+++ b/src/main/java/com/leets/xcellentbe/global/auth/login/AuthController.java
@@ -41,13 +41,14 @@ public class AuthController {
 		return "로그인 성공";
 	}
 
+	@Operation(summary = "이메일 인증", description = "이메일 인증을 합니다.")
 	@PostMapping("/email/send")
-	public ResponseEntity<GlobalResponseDto<String>> mailSend(@RequestBody EmailRequestDto emailRequestDto) throws
-		MessagingException {
+	public ResponseEntity<GlobalResponseDto<String>> mailSend(@RequestBody EmailRequestDto emailRequestDto) {
 		emailService.joinEmail(emailRequestDto.getEmail());
 		return ResponseEntity.status(HttpStatus.OK).body(GlobalResponseDto.success());
 	}
 
+	@Operation(summary = "이메일 인증 확인", description = "이메일 인증을 확인합니다.")
 	@PostMapping("/email/check")
 	public ResponseEntity<GlobalResponseDto<String>> AuthCheck(@RequestBody EmailCheckDto emailCheckDto) {
 		return ResponseEntity.status(HttpStatus.OK).body(GlobalResponseDto.success(emailService.checkAuthNum(emailCheckDto.getEmail(), emailCheckDto.getAuthNum())));

--- a/src/main/java/com/leets/xcellentbe/global/config/AwsConfig.java
+++ b/src/main/java/com/leets/xcellentbe/global/config/AwsConfig.java
@@ -1,0 +1,35 @@
+package com.leets.xcellentbe.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsConfig {
+
+	// S3를 등록한 사람이 전달받은 접속하기 위한 key 값
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	// S3를 등록한 사람이 전달받은 접속하기 위한 secret key 값
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	// S3를 등록한 사람이 S3를 사용할 지역
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	// 전달받은 Accesskey 와 SecretKey 로 아마존 서비스 실행 준비
+	@Bean
+	public AmazonS3Client amazonS3Client() {
+		BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+		return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+			.build();
+	}
+}

--- a/src/main/java/com/leets/xcellentbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/xcellentbe/global/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
 				authorize ->
 					authorize
 						.requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**",
-							"/swagger/**", "/api/auth/register", "/api/auth/login", "/index.html", "/api/auth/**").permitAll()
+							"/swagger/**", "/index.html", "/api/auth/**").permitAll()
 						.anyRequest().authenticated()
 			)
 			.oauth2Login(oauth2 -> oauth2.successHandler(oAuthLoginSuccessHandler));

--- a/src/main/java/com/leets/xcellentbe/global/error/ErrorCode.java
+++ b/src/main/java/com/leets/xcellentbe/global/error/ErrorCode.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ErrorCode {
 
 	INVALID_INPUT_VALUE(400, "INVALID_INPUT_VALUE", "유효하지 않은 입력값입니다."),
+	INVALID_FILE_FORMAT(400, "INVALID_FILE_FORMAT", "올바르지 않은 파일 형식입니다."),
 	INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
 	LOGIN_FAIL(401, "LOGIN_FAIL", "로그인에 실패하였습니다."),
 	CHAT_ROOM_FORBIDDEN(403, "CHAT_ROOM_FORBIDDEN","권한이 없는 채팅방입니다."),

--- a/src/main/java/com/leets/xcellentbe/global/error/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/leets/xcellentbe/global/error/exception/GlobalExceptionHandler.java
@@ -20,13 +20,13 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(HttpStatus.valueOf(errorCode.getStatus())).body(GlobalResponseDto.fail(errorCode, errorResponse.getMessage()));
 	}
 
-	// @ExceptionHandler(Exception.class)
-	// public ResponseEntity<GlobalResponseDto> handleGenericException(Exception ex) {
-	// 	ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-	// 	ErrorResponse errorResponse = new ErrorResponse(errorCode);
-	// 	showErrorLog(errorCode);
-	// 	return ResponseEntity.status(HttpStatus.valueOf(errorCode.getStatus())).body(GlobalResponseDto.fail(errorCode, errorResponse.getMessage()));
-	// }
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<GlobalResponseDto> handleGenericException(Exception ex) {
+		ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+		ErrorResponse errorResponse = new ErrorResponse(errorCode);
+		showErrorLog(errorCode);
+		return ResponseEntity.status(HttpStatus.valueOf(errorCode.getStatus())).body(GlobalResponseDto.fail(errorCode, errorResponse.getMessage()));
+	}
 
 
 	private static void showErrorLog(ErrorCode errorCode) {

--- a/src/main/java/com/leets/xcellentbe/global/error/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/leets/xcellentbe/global/error/exception/GlobalExceptionHandler.java
@@ -20,13 +20,13 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(HttpStatus.valueOf(errorCode.getStatus())).body(GlobalResponseDto.fail(errorCode, errorResponse.getMessage()));
 	}
 
-	@ExceptionHandler(Exception.class)
-	public ResponseEntity<GlobalResponseDto> handleGenericException(Exception ex) {
-		ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-		ErrorResponse errorResponse = new ErrorResponse(errorCode);
-		showErrorLog(errorCode);
-		return ResponseEntity.status(HttpStatus.valueOf(errorCode.getStatus())).body(GlobalResponseDto.fail(errorCode, errorResponse.getMessage()));
-	}
+	// @ExceptionHandler(Exception.class)
+	// public ResponseEntity<GlobalResponseDto> handleGenericException(Exception ex) {
+	// 	ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+	// 	ErrorResponse errorResponse = new ErrorResponse(errorCode);
+	// 	showErrorLog(errorCode);
+	// 	return ResponseEntity.status(HttpStatus.valueOf(errorCode.getStatus())).body(GlobalResponseDto.fail(errorCode, errorResponse.getMessage()));
+	// }
 
 
 	private static void showErrorLog(ErrorCode errorCode) {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
프로필 정보 조회 / 프로필 업데이트(수정)
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
1. 프로필 정보를 수정하는 API를 생성하는 도중, `PUT` 메소드와 `PATCH` 메소드중 어떤 메소드를 사용할지 고민했습니다.
결론은 회원 정보 수정의 경우 정보를 `GET` 해오고, 이를 바탕으로 다시 수정을 진행하기 때문에 `PUT`을 사용해도 크게 문제가 되지 않을거 같아 `PUT` 메소드를 사용 하였습니다.
2. 프로필 이미지 변경과 배경 변경의 경우에는 API를 분리하여 생성하였습니다 `X` 특성상 프로필 이미지 변경와 배경 변경은 직접 사용자가 이미지를 클릭하여 변경하는 방식이 UX 측면에서 좀 더 효율적이라고 생각하여 분리하였습니다. 추후 프론트엔드와의 협의를 통해 `회원 정보 수정 API`와 통합이 필요할시 통합 할 예정입니다.
3. 사용자에게 이미지를 받을 때, 어떤 확장자만 허용할지에 대해서 논의가 필요할 것 같습니다.
4. 사용자 정보 조회 및 수정의 경우엔, 기존에는 URL의 `PathVariable`을 통해 사용자의 `Email` 혹은 `CustomId`을 기준으로 접근하여 진행할 예정이였습니다. 그러나 이러한 방식으로 구현 할 경우 다른 사용자가 API를 악용할 우려가 있어 헤더에서 JWT 토큰을 추출하여 본인의 정보만 접근가능하게 구현하였습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="786" alt="image" src="https://github.com/user-attachments/assets/f609a938-882c-418f-8f98-4d37f64ce039">

최초 회원가입

<img width="790" alt="image" src="https://github.com/user-attachments/assets/98af9396-c9c2-4f6f-bfe7-2e42249e3ab6">

프로필 이미지 변경 요청

<img width="786" alt="image" src="https://github.com/user-attachments/assets/f6eb802c-5108-4bd0-9480-30aaab109d54">

프로필 수정 요청

<img width="465" alt="image" src="https://github.com/user-attachments/assets/ef9a8115-7a7f-475c-bd5f-36acda3f3e0b">


<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
