### PR TITLE
[fix] #25 유저정보 반환 KEY 값 수정

### DIFF
--- a/src/main/java/com/leets/xcellentbe/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/dto/UserProfileResponseDto.java
@@ -1,6 +1,5 @@
 package com.leets.xcellentbe.domain.user.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.leets.xcellentbe.domain.user.domain.User;
 
 import lombok.Builder;
@@ -24,11 +23,7 @@ public class UserProfileResponseDto {
 	private int userBirthDay;
 	private int followersCount;
 	private int followingsCount;
-
-	@JsonProperty("isFollowing")
 	private Boolean isFollowing;
-
-	@JsonProperty("isMyProfile")
 	private Boolean isMyProfile;
 
 	@Builder

--- a/src/main/java/com/leets/xcellentbe/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/dto/UserProfileResponseDto.java
@@ -26,16 +26,16 @@ public class UserProfileResponseDto {
 	private int followingsCount;
 
 	@JsonProperty("isFollowing")
-	private boolean isFollowing;
+	private Boolean isFollowing;
 
 	@JsonProperty("isMyProfile")
-	private boolean isMyProfile;
+	private Boolean isMyProfile;
 
 	@Builder
 	private UserProfileResponseDto(String email, String customId, String userName, String profileImageUrl,
 		String backgroundProfileImageUrl, String phoneNumber, String description, String websiteUrl, String location,
 		int userBirthYear, int userBirthMonth, int userBirthDay, int followersCount, int followingsCount,
-		boolean isFollowing, boolean isMyProfile) {
+		Boolean isFollowing, Boolean isMyProfile) {
 		this.email = email;
 		this.customId = customId;
 		this.userName = userName;
@@ -54,8 +54,8 @@ public class UserProfileResponseDto {
 		this.isFollowing = isFollowing;
 	}
 
-	public static UserProfileResponseDto from(User user, int followersCount, int followingsCount, boolean isFollowing,
-		boolean isMyProfile) {
+	public static UserProfileResponseDto from(User user, int followersCount, int followingsCount, Boolean isFollowing,
+		Boolean isMyProfile) {
 		return UserProfileResponseDto.builder()
 			.email(user.getEmail())
 			.customId(user.getCustomId())

--- a/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/xcellentbe/domain/user/service/UserService.java
@@ -57,7 +57,7 @@ public class UserService {
 
 		int followerCount = followRepository.countByFollowing(user);
 		int followingCount = followRepository.countByFollower(user);
-		
+
 		return UserProfileResponseDto.from(user, followerCount, followingCount, false, true);
 	}
 
@@ -66,8 +66,8 @@ public class UserService {
 		User myinfo = getUser(request);
 		User user = userRepository.findByCustomId(customId).orElseThrow(UserNotFoundException::new);
 
-		boolean isMyProfile = myinfo.equals(user);
-		boolean isFollowing = followRepository.findByFollowerAndFollowing(myinfo, user).isPresent();
+		Boolean isMyProfile = myinfo.equals(user);
+		Boolean isFollowing = followRepository.findByFollowerAndFollowing(myinfo, user).isPresent();
 
 		int followerCount = followRepository.countByFollowing(user);
 		int followingCount = followRepository.countByFollower(user);


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

Response 오류 수정
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

같은 값이 두번 중복되어 반환되던 오류 해결

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항

기존 boolean으로 반환하던 값을 Boolean으로 변환하였습니다.

<br>

## 5. 추가 사항

> boolean 타입이면서 is로 시작하고 이어서 대문자로 시작하는 필드의 경우, getter를 생성할 때 추가적인 접두어가 붙지 않는다. 그러나 boolean과 관련된 다른 경우, 즉 Boolean과 같은 참조 타입의 경우에는 is 접두어 대신 get 접두어를 사용한다.

라고 합니다. 알아두면 좋으실 것 같습니다,,


https://velog.io/@dongjae0803/is%EA%B0%80-%EC%82%AC%EB%9D%BC%EC%A7%84%EB%8B%A4-Boolean%EA%B3%BC-boolean%EC%9D%98-%EC%B0%A8%EC%9D%B4


